### PR TITLE
Fixed track thumbnail is always undefined

### DIFF
--- a/lib/Track.ts
+++ b/lib/Track.ts
@@ -18,7 +18,7 @@ export default class Track {
 
   constructor(data: ITrack) {
     this.identifier = data.info.identifier;
-    if (data.info.thumbnail) this.thumbnailUrl = data.info.thumbnail;
+    this.thumbnailUrl = `https://img.youtube.com/vi/${data.info.identifier}/sddefault.jpg`;
     this.isSeekable = data.info.isSeekable;
     this.author = data.info.author;
     this.duration = data.info.length;


### PR DESCRIPTION
Response track thumbnail results are always undefined, however, there's no property that exists called `data.info.thumbnail`. YouTube videos always will have video ID, by using that ID we can get video thumbnails instead of relying on lavalink.

Before:
![image](https://user-images.githubusercontent.com/71683721/159993057-318526e8-5995-4429-8868-100204f449ab.png)


After:
![image](https://user-images.githubusercontent.com/71683721/159992872-947c2aa5-dfe6-4bd5-ac5a-9373a6fba044.png)


As we can see there's no property existing name thumbnail
![image](https://user-images.githubusercontent.com/71683721/159993301-2c7c9943-1859-4e9f-be58-4c5cd3418c66.png)

