### PR TITLE
Player queue abstraction

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -5,6 +5,7 @@ import Track from './lib/Track';
 import UnresolvedTrack from './lib/UnresolvedTrack';
 import { Vulkava } from './lib/Vulkava';
 import { AbstractExternalSource } from './lib/sources/AbstractExternalSource';
+import { AbstractQueue } from './lib/queue/AbstractQueue';
 
 import type {
   NodeOptions,
@@ -24,6 +25,7 @@ export {
   UnresolvedTrack,
   Vulkava,
 
+  AbstractQueue,
   AbstractExternalSource,
 
   NodeState,

--- a/lib/@types/index.ts
+++ b/lib/@types/index.ts
@@ -1,5 +1,6 @@
 import { Node } from '../..';
 import Player from '../Player';
+import { AbstractQueue } from '../queue/AbstractQueue';
 import Track from '../Track';
 import UnresolvedTrack from '../UnresolvedTrack';
 
@@ -285,6 +286,8 @@ export type PlayerOptions = {
   selfDeaf?: boolean;
   /** Whether the bot joins the voice channel muted or not */
   selfMute?: boolean;
+  /** The queue object that player will use */
+  queue?: AbstractQueue;
 };
 
 export type VoiceState = {

--- a/lib/Node.ts
+++ b/lib/Node.ts
@@ -267,7 +267,7 @@ export default class Node {
   }
 
   private async pollTrack(player: Player) {
-    let newTrack = player.queue.shift() ?? null;
+    let newTrack = player.queue.poll();
 
     if (newTrack) {
       if (newTrack instanceof UnresolvedTrack) {
@@ -331,7 +331,7 @@ export default class Node {
   private async handleTrackEnd(ev: TrackEndEvent, player: Player) {
     if (ev.reason === 'REPLACED') {
       if (player.queueRepeat && player.current) {
-        player.queue.push(player.current);
+        player.queue.add(player.current);
       }
       return;
     }
@@ -353,7 +353,7 @@ export default class Node {
     }
 
     if (player.queueRepeat && player.current) {
-      player.queue.push(player.current);
+      player.queue.add(player.current);
     }
 
     this.pollTrack(player);

--- a/lib/Vulkava.ts
+++ b/lib/Vulkava.ts
@@ -202,6 +202,7 @@ export class Vulkava extends EventEmitter {
    * @param {String} [options.textChannelId] - The text channel id
    * @param {Boolean} [options.selfDeaf=false] - Whether the bot joins the voice channel deafened or not
    * @param {Boolean} [options.selfMute=false] - Whether the bot joins the voice channel muted or not
+   * @param {AbstractQueue} [options.queue] - The queue for this player
    * @returns {Player}
    */
   public createPlayer(options: PlayerOptions): Player {

--- a/lib/queue/AbstractQueue.ts
+++ b/lib/queue/AbstractQueue.ts
@@ -1,0 +1,45 @@
+import Track from '../Track';
+import UnresolvedTrack from '../UnresolvedTrack';
+
+export abstract class AbstractQueue {
+  /**
+   * Gets the queue duration
+   * @abstract
+   * @type {number}
+   */
+  abstract get duration(): number;
+
+  /**
+   * Gets the queue size
+   * @abstract
+   * @type {number}
+   */
+  abstract get size(): number;
+
+  /**
+   * Adds a track to the queue
+   * @abstract
+   * @param {Track | UnresolvedTrack} track - The track to add to the queue
+   */
+  abstract add(track: Track | UnresolvedTrack): void;
+
+  /**
+   * Polls the queue for the next track.
+   * @abstract
+   * @return {Track | UnresolvedTrack | null} The next track in the queue or null if the queue is empty.
+   */
+  abstract poll(): Track | UnresolvedTrack | null;
+
+  /**
+   * Remove the next n tracks from the queue
+   * @abstract
+   * @param {number} n - The number of tracks to skip
+   */
+  abstract skipNTracks(n: number): void;
+
+  /**
+   * Clears the queue.
+   * @abstract
+   */
+  abstract clear(): void;
+}

--- a/lib/queue/DefaultQueue.ts
+++ b/lib/queue/DefaultQueue.ts
@@ -1,0 +1,80 @@
+import Track from '../Track';
+import UnresolvedTrack from '../UnresolvedTrack';
+import { AbstractQueue } from './AbstractQueue';
+
+export class DefaultQueue extends AbstractQueue {
+  private tracks: Array<Track | UnresolvedTrack>;
+
+  constructor() {
+    super();
+    this.tracks = [];
+  }
+
+  /**
+   * Gets the queue size.
+   */
+  get size(): number {
+    return this.tracks.length;
+  }
+
+  /**
+   * Gets the queue duration in milliseconds.
+   */
+  get duration(): number {
+    return this.tracks.reduce((acc, track) => acc + track.duration, 0);
+  }
+
+  /**
+   * Adds a track to the queue.
+   * @param {Track | UnresolvedTrack} track - The track to add to the queue
+   * @deprecated - Use `add()` instead
+   */
+  public push(track: Track | UnresolvedTrack) {
+    this.tracks.push(track);
+  }
+
+  /**
+   * Adds a track to the queue.
+   * @param {Track | UnresolvedTrack} track - The track to add to the queue
+   */
+  public add(track: Track | UnresolvedTrack) {
+    this.tracks.push(track);
+  }
+
+  /**
+   * Polls the queue for the next track.
+   * @returns {Track | UnresolvedTrack | null} The next track in the queue or null if the queue is empty.
+   */
+  public poll(): Track | UnresolvedTrack | null {
+    return this.tracks.shift() ?? null;
+  }
+
+  /**
+   * Remove the next n tracks from the queue
+   * @param {number} n - The number of tracks to skip
+   */
+  public skipNTracks(n: number) {
+    this.tracks.splice(0, n - 1);
+  }
+
+  /**
+   * Shuffles the queue
+   */
+  public shuffle() {
+    if (this.tracks.length) {
+      let j;
+      for (let i = this.tracks.length - 1; i; i--) {
+        j = Math.floor(Math.random() * (i + 1));
+
+        [this.tracks[i], this.tracks[j]] = [this.tracks[j], this.tracks[i]];
+      }
+    }
+  }
+
+  /**
+   * Clears the queue.
+   */
+  public clear() {
+    this.tracks = [];
+  }
+}


### PR DESCRIPTION
Adds abstraction for player queue.

- The custom queue must extend AbstractQueue class (see DefaultQueue.ts example)

How to inject a custom queue instance:
-----
```js
const myCustomQueue = new MyQueue();

const player = <vulkava>.createPlayer({
    // (...)
    queue: myCustomQueue
});
```

Closes #11 