### PR TITLE
Add get tracks method to DefaultQueue

### DIFF
--- a/lib/queue/DefaultQueue.ts
+++ b/lib/queue/DefaultQueue.ts
@@ -25,6 +25,13 @@ export class DefaultQueue extends AbstractQueue {
   }
 
   /**
+   * Gets all tracks in the queue
+   */
+  get tracks(): Track[] {
+    return this.tracks
+  }
+
+  /**
    * Adds a track to the queue.
    * @param {Track | UnresolvedTrack} track - The track to add to the queue
    * @deprecated - Use `add()` instead


### PR DESCRIPTION
Although we can extend the DefaultQueue class we can also access tracks property on the DefaultQueue class by default so there is no sense it not being reachable x)