### PR TITLE
Making the library more compatible with the lavasrc plugin

### DIFF
--- a/lib/@types/index.ts
+++ b/lib/@types/index.ts
@@ -97,7 +97,7 @@ export type EventListeners<T> = {
   (event: 'userDisconnect', listener: (player: Player, userId: string) => void): T;
 }
 
-// Search sources (spotify, apple music and deezer work only with the https://github.com/topi314/LavaSrc plugin (though urls work by default) the last two only work on my lavalink (https://github.com/davidffa/lavalink/releases) )
+// Search sources (spotify, apple music and deezer only work with the https://github.com/topi314/LavaSrc plugin (though urls work by default) the last two only work on my lavalink (https://github.com/davidffa/lavalink/releases) )
 export type SEARCH_SOURCE = 'youtube' | 'youtubemusic' | 'spotify' | 'applemusic' | 'deezer' | 'soundcloud' | 'odysee' | 'yandex';
 
 // -- REST --

--- a/lib/@types/index.ts
+++ b/lib/@types/index.ts
@@ -63,9 +63,9 @@ export type VulkavaOptions = {
   defaultSearchSource?: SEARCH_SOURCE;
   /** The default source to search for unresolved tracks */
   unresolvedSearchSource?: SEARCH_SOURCE;
-  /** The spotify credentials */
+  /** The spotify credentials. Not needed if you use the lavasrc plugin. */
   spotify?: SpotifyConfig;
-  /** Disables spotify, apple music or deezer */
+  /** Disables spotify, apple music or deezer. Doesn't have any effect if you use the lavasrc plugin. */
   disabledSources?: UNRESOLVED_SOURCES[];
   /** Whether to search for ISRC to resolve tracks or not */
   useISRC?: boolean;
@@ -97,8 +97,8 @@ export type EventListeners<T> = {
   (event: 'userDisconnect', listener: (player: Player, userId: string) => void): T;
 }
 
-// Search sources (the last two only works on my lavalink (https://github.com/davidffa/lavalink/releases) )
-export type SEARCH_SOURCE = 'youtube' | 'youtubemusic' | 'soundcloud' | 'odysee' | 'yandex';
+// Search sources (spotify, apple music and deezer work only with the https://github.com/topi314/LavaSrc plugin (though urls work by default) the last two only work on my lavalink (https://github.com/davidffa/lavalink/releases) )
+export type SEARCH_SOURCE = 'youtube' | 'youtubemusic' | 'spotify' | 'applemusic' | 'deezer' | 'soundcloud' | 'odysee' | 'yandex';
 
 // -- REST --
 

--- a/lib/Vulkava.ts
+++ b/lib/Vulkava.ts
@@ -102,7 +102,7 @@ export class Vulkava extends EventEmitter {
    * @param {String} [options.spotify.clientId] - The spotify client id
    * @param {String} [options.spotify.clientSecret] - The spotify client secret
    * @param {String} [options.spotify.market] - The spotify market
-   * @param {Array<String>} [options.disabledSources] - Disables, apple music, deezer or spotify
+   * @param {Array<String>} [options.disabledSources] - Disables apple music, deezer or spotify. Doesn't have any effect if you use the lavasrc plugin.
    * @param {Boolean} [options.useISRC] - Whether to use ISRC to resolve tracks or not
    * @param {Function} options.sendWS - The function to send websocket messages to the main gateway
    */
@@ -228,7 +228,7 @@ export class Vulkava extends EventEmitter {
   /**
    *
    * @param {String} query - The query to search for
-   * @param {('youtube' | 'youtubemusic' | 'spotify' | 'applemusic' | 'deezer'| 'soundcloud' | 'odysee' | 'yandex')} [source=youtube] - The search source. Spotify, Apple Music and Deezer search are not supported by default (only urls are supported by default), you can use the https://github.com/topi314/LavaSrc to enable them.
+   * @param {('youtube' | 'youtubemusic' | 'spotify' | 'applemusic' | 'deezer'| 'soundcloud' | 'odysee' | 'yandex')} [source=youtube] - The search source. spotify, apple music and deezer search are not supported by default (only urls are supported by default), you can use the https://github.com/topi314/LavaSrc plugin to enable them.
    * @returns {Promise<SearchResult>}
    */
   public async search(query: string, source: SEARCH_SOURCE = this.defaultSearchSource): Promise<SearchResult> {

--- a/lib/Vulkava.ts
+++ b/lib/Vulkava.ts
@@ -232,7 +232,9 @@ export class Vulkava extends EventEmitter {
    * @returns {Promise<SearchResult>}
    */
   public async search(query: string, source: SEARCH_SOURCE = this.defaultSearchSource): Promise<SearchResult> {
-    if (typeof query !== 'string') { throw new TypeError('Search query must be a non-empty string'); }
+    if (typeof query !== 'string') {
+      throw new TypeError('Search query must be a non-empty string');
+    }
 
     for (const source of this.externalSources) {
       const loadRes = await source.loadItem(query);

--- a/lib/Vulkava.ts
+++ b/lib/Vulkava.ts
@@ -98,7 +98,7 @@ export class Vulkava extends EventEmitter {
    * @param {Number} [options.nodes[].retryAttemptsInterval] - The interval between retry attempts
    * @param {String} [options.defaultSearchSource] - The default search source
    * @param {String} [options.unresolvedSearchSource] - The unresolved search source
-   * @param {Object} [options.spotify] - The spotify credential options
+   * @param {Object} [options.spotify] - The spotify credential options. Not needed if you use the lavasrc plugin.
    * @param {String} [options.spotify.clientId] - The spotify client id
    * @param {String} [options.spotify.clientSecret] - The spotify client secret
    * @param {String} [options.spotify.market] - The spotify market

--- a/lib/Vulkava.ts
+++ b/lib/Vulkava.ts
@@ -228,7 +228,7 @@ export class Vulkava extends EventEmitter {
   /**
    *
    * @param {String} query - The query to search for
-   * @param {('youtube' | 'youtubemusic' | 'soundcloud' | 'odysee' | 'yandex')} [source=youtube] - The search source
+   * @param {('youtube' | 'youtubemusic' | 'spotify' | 'applemusic' | 'deezer'| 'soundcloud' | 'odysee' | 'yandex')} [source=youtube] - The search source. Spotify, Apple Music and Deezer search are not supported by default (only urls are supported by default), you can use the https://github.com/topi314/LavaSrc to enable them.
    * @returns {Promise<SearchResult>}
    */
   public async search(query: string, source: SEARCH_SOURCE = this.defaultSearchSource): Promise<SearchResult> {
@@ -243,6 +243,9 @@ export class Vulkava extends EventEmitter {
     const sourceMap = {
       youtube: 'ytsearch:',
       youtubemusic: 'ytmsearch:',
+      spotify: 'spsearch:',
+      applemusic: 'amsearch:',
+      deezer: 'dzisearch:',
       soundcloud: 'scsearch:',
       odysee: 'odsearch:',
       yandex: 'ymsearch:'


### PR DESCRIPTION
Adds the option of searching directly via text on spotify, apple music or deezer, which are added by the lavasrc plugin.