### PR TITLE
Update Vulkava event listeners typings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ typings
 
 yarn.lock
 package-lock.json
+bun.lockb
 
 coverage

--- a/lib/@types/index.ts
+++ b/lib/@types/index.ts
@@ -72,29 +72,77 @@ export type VulkavaOptions = {
 };
 
 /** Vulkava events */
-export type EventListeners<T> = {
-  (event: 'debug', listener: (message: string) => void): T;
-  (event: 'raw', listener: (node: Node, payload: unknown) => void): T;
-  (event: 'nodeConnect', listener: (node: Node) => void): T;
-  (event: 'nodeResume', listener: (node: Node) => void): T;
-  (event: 'nodeDisconnect', listener: (node: Node, code: number, reason: string) => void): T;
-  (event: 'warn', listener: (node: Node, warn: string) => void): T;
-  (event: 'error', listener: (node: Node, error: Error) => void): T;
-  (event: 'trackStart', listener: (player: Player, track: Track) => void): T;
-  (event: 'trackEnd', listener: (player: Player, track: Track, reason: TrackEndReason) => void): T;
-  (event: 'trackStuck', listener: (player: Player, track: Track, thresholdMs: number) => void): T;
-  (event: 'trackException', listener: (player: Player, track: Track | UnresolvedTrack, exception: LoadException & { cause: string }) => void): T;
-  (event: 'playerCreate', listener: (player: Player) => void): T;
-  (event: 'playerDestroy', listener: (player: Player) => void): T;
-  (event: 'playerDisconnect', listener: (player: Player, code: number, reason: string) => void): T;
-  (event: 'queueEnd', listener: (player: Player) => void): T;
-  (event: 'pong', listener: (node: Node, ping?: number) => void): T;
-  (event: 'recordFinished', listener: (node: Node, guildId: string, id: string) => void): T;
+export interface VulkavaEvents {
+  debug: [message: string];
+  raw: [
+    node: Node,
+    payload: unknown,
+  ];
+  nodeConnect: [node: Node];
+  nodeResume: [node: Node];
+  nodeDisconnect: [
+    node: Node,
+    code: number,
+    reason: string,
+  ];
+  warn: [
+    node: Node,
+    warn: string,
+  ];
+  error: [
+    node: Node,
+    error: Error,
+  ];
+  trackStart: [
+    player: Player,
+    track: Track,
+  ];
+  trackEnd: [
+    player: Player,
+    track: Track,
+    reason: TrackEndReason,
+  ];
+  trackStuck: [
+    player: Player,
+    track: Track,
+    thresholdMs: number,
+  ];
+  trackException: [
+    player: Player,
+    track: Track | UnresolvedTrack,
+    exception: LoadException & { cause: string },
+  ];
+  playerCreate: [player: Player];
+  playerDestroy: [player: Player];
+  playerDisconnect: [
+    player: Player,
+    code: number,
+    reason: string,
+  ];
+  queueEnd: [player: Player];
+  pong: [
+    node: Node,
+    ping?: number,
+  ];
+  recordFinished: [
+    node: Node,
+    guildId: string,
+    id: string,
+  ];
 
-  // Speaking Events (only work on my lavalink (https://github.com/davidffa/lavalink/releases) and while recording audio )
-  (event: 'speakingStart', listener: (player: Player, userId: string) => void): T;
-  (event: 'speakingStop', listener: (player: Player, userId: string) => void): T;
-  (event: 'userDisconnect', listener: (player: Player, userId: string) => void): T;
+  // Speaking Events (only work on my lavalink (https://github.com/davidffa/lavalink/releases) and while recording audio)
+  speakingStart: [
+    player: Player,
+    userId: string,
+  ];
+  speakingStop: [
+    player: Player,
+    userId: string,
+  ];
+  userDisconnect: [
+    player: Player,
+    userId: string,
+  ];
 }
 
 // Search sources (the last two only works on my lavalink (https://github.com/davidffa/lavalink/releases) )

--- a/lib/Vulkava.ts
+++ b/lib/Vulkava.ts
@@ -21,6 +21,7 @@ import type {
   VulkavaOptions
 } from './@types';
 
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface Vulkava {
   on<Event extends keyof VulkavaEvents>(event: Event, listener: (...args: VulkavaEvents[Event]) => void): this;
   once<Event extends keyof VulkavaEvents>(event: Event, listener: (...args: VulkavaEvents[Event]) => void): this;

--- a/lib/Vulkava.ts
+++ b/lib/Vulkava.ts
@@ -12,7 +12,7 @@ import Spotify from './sources/Spotify';
 import type {
   IncomingDiscordPayload,
   OutgoingDiscordPayload,
-  EventListeners,
+  VulkavaEvents,
   PlayerOptions,
   SearchResult,
   SEARCH_SOURCE,
@@ -21,10 +21,9 @@ import type {
   VulkavaOptions
 } from './@types';
 
-// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface Vulkava {
-  once: EventListeners<this>;
-  on: EventListeners<this>;
+  on<Event extends keyof VulkavaEvents>(event: Event, listener: (...args: VulkavaEvents[Event]) => void): this;
+  once<Event extends keyof VulkavaEvents>(event: Event, listener: (...args: VulkavaEvents[Event]) => void): this;
 }
 
 /**


### PR DESCRIPTION
This PR changes how the event typings are defined, changing it from a type to an interface, allowing it to be used for better type autocompletions and type manipulation